### PR TITLE
feature: add GitHub data collector

### DIFF
--- a/app/basic/Utils.ts
+++ b/app/basic/Utils.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { mergeWith, isArray } from 'lodash';
+import waitFor from 'p-wait-for';
 
 export function parseRepoName(fullName: string): { owner: string, repo: string } {
   const s = fullName.split('/');
@@ -105,4 +106,8 @@ export interface BotLogger {
   info: (msg: any, ...args: any[]) => void;
   warn: (msg: any, ...args: any[]) => void;
   error: (msg: any, ...args: any[]) => void;
+}
+
+export function waitUntil(func: () => boolean, options?: object): Promise<void> {
+  return waitFor(func, Object.assign({ interval: 1000 }, options));
 }

--- a/app/plugin/github-installation-manager/GitHubInstallationConfig.ts
+++ b/app/plugin/github-installation-manager/GitHubInstallationConfig.ts
@@ -23,4 +23,7 @@ export class GitHubInstallationConfig {
     secret: string;
     proxyUrl: string;
   };
+  fetcher: {
+    tokens: string[];
+  };
 }

--- a/app/plugin/github-installation-manager/github-client/GitHubClient.ts
+++ b/app/plugin/github-installation-manager/github-client/GitHubClient.ts
@@ -14,7 +14,7 @@
 
 import Octokit = require('@octokit/rest');
 import { IClient } from '../../installation-manager/IClient';
-import { parseRepoName, BotLogger } from '../../../basic/Utils';
+import { parseRepoName, BotLogger, waitUntil, ParseDate } from '../../../basic/Utils';
 import { GitHubInstallation } from '../github-installation/GitHubInstallation';
 import { Repo } from '../../../basic/DataTypes';
 
@@ -40,6 +40,75 @@ export class GitHubClient implements IClient {
 
   private async updateData(): Promise<void> {
     this.logger.info(`Start to update data for ${this.name} in ${this.installation.id}`);
+
+    const dataCat = this.installation.dataCat;
+    await waitUntil(() => dataCat.inited);
+
+    const full = await dataCat.repo.full(this.owner, this.repo, {
+        contributors: true,
+        issues: true,
+        stars: true,
+        forks: true,
+        pulls: true,
+      });
+
+    this.repoData = {
+      ...full,
+      stars: full.stars.map(star => {
+        return {
+          ...star,
+          time: new Date(star.time),
+        };
+      }),
+      forks: full.forks.map(fork => {
+        return {
+          ...fork,
+          time: new Date(fork.time),
+        };
+      }),
+      issues: full.issues.map(issue => {
+        return {
+          ...issue,
+          createdAt: new Date(issue.createdAt),
+          updatedAt: new Date(issue.updatedAt),
+          closedAt: ParseDate(issue.closedAt),
+          comments: issue.comments.map(comment => {
+            return {
+              ...comment,
+              createdAt: new Date(comment.createdAt),
+            };
+          }),
+        };
+      }),
+      pulls: full.pulls.map(pull => {
+        return {
+          ...pull,
+          createdAt: new Date(pull.createdAt),
+          updatedAt: new Date(pull.updatedAt),
+          closedAt: ParseDate(pull.closedAt),
+          mergedAt: ParseDate(pull.mergedAt),
+          comments: pull.comments.map(c => {
+            return {
+              ...c,
+              createdAt: new Date(c.createdAt),
+            };
+          }),
+          reviewComments: pull.reviewComments.map(rc => {
+            return {
+              ...rc,
+              createdAt: new Date(rc.createdAt),
+            };
+          }),
+        };
+      }),
+      contributors: full.contributors.map(c => {
+        return {
+          ...c,
+          time: new Date(c.time),
+        };
+      }),
+    };
+    console.log(JSON.stringify(this.repoData));
   }
 
   public async getFileContent(path: string): Promise<string | undefined > {

--- a/app/plugin/github-installation-manager/github-installation/GitHubInstallation.ts
+++ b/app/plugin/github-installation-manager/github-installation/GitHubInstallation.ts
@@ -21,6 +21,7 @@ import { BotLogger } from '../../../basic/Utils';
 import EventSource from 'eventsource';
 import { join } from 'path';
 import { Context } from 'egg';
+import { DataCat } from 'github-data-cat';
 
 type ClientGenerator = () => Promise<GitHubClient>;
 
@@ -29,6 +30,7 @@ export class GitHubInstallation {
   public id: number;
   public githubInstallationManager: AppGitHubInstallationManager;
   public webhooks: Webhooks;
+  public dataCat: DataCat;
 
   private clients: Map<string, ClientGenerator>;
   private logger: BotLogger;
@@ -38,6 +40,10 @@ export class GitHubInstallation {
     this.githubInstallationManager = mgr;
     this.logger = mgr.logger;
     this.clients = new Map<string, ClientGenerator>();
+    this.dataCat = new DataCat({
+      tokens: config.fetcher.tokens,
+    });
+    this.dataCat.init();
     this.initWebhooks(config);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,6 +241,16 @@
         }
       }
     },
+    "@octokit/graphql": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npm.taobao.org/@octokit/graphql/download/@octokit/graphql-4.3.1.tgz",
+      "integrity": "sha1-nuhA4E7SkGx9Z2OAdjLehM3s9Bg=",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^2.0.0",
+        "universal-user-agent": "^4.0.0"
+      }
+    },
     "@octokit/request": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
@@ -2042,6 +2052,17 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "bunyan": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npm.taobao.org/bunyan/download/bunyan-1.8.12.tgz",
+      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "requires": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.10.6",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
+    },
     "busboy": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
@@ -2801,6 +2822,15 @@
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
+      }
+    },
+    "dtrace-provider": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npm.taobao.org/dtrace-provider/download/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha1-KZbVSQw34TR74mO0I+17KX+w2X4=",
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.0"
       }
     },
     "duplexer": {
@@ -4916,6 +4946,33 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
+    "github-data-cat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npm.taobao.org/github-data-cat/download/github-data-cat-1.0.1.tgz",
+      "integrity": "sha1-sBzFQnylT2218cIE0fvx/WmGLpA=",
+      "requires": {
+        "@types/node": "^12.11.1",
+        "bunyan": "^1.8.12",
+        "github-graphql-v4-client": "^0.1.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.11",
+          "resolved": "https://registry.npm.taobao.org/@types/node/download/@types/node-12.12.11.tgz",
+          "integrity": "sha1-vsKWGXWIjZZBlr8AFqL5hNeT084="
+        }
+      }
+    },
+    "github-graphql-v4-client": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npm.taobao.org/github-graphql-v4-client/download/github-graphql-v4-client-0.1.0.tgz",
+      "integrity": "sha1-NpX0Z5NQpPfk2zp+ywllDYQaaGY=",
+      "requires": {
+        "@octokit/graphql": "^4.0.0",
+        "bunyan": "^1.8.12",
+        "p-wait-for": "^3.1.0"
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -6269,6 +6326,41 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
       "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="
     },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npm.taobao.org/mv/download/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npm.taobao.org/glob/download/glob-6.0.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglob%2Fdownload%2Fglob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npm.taobao.org/rimraf/download/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "optional": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
+        }
+      }
+    },
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -6295,7 +6387,6 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
       "optional": true
     },
     "nanoid": {
@@ -6339,6 +6430,12 @@
           }
         }
       }
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/ncp/download/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true
     },
     "ndir": {
       "version": "0.1.5",
@@ -7786,10 +7883,26 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npm.taobao.org/p-timeout/download/p-timeout-3.2.0.tgz",
+      "integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "p-wait-for": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npm.taobao.org/p-wait-for/download/p-wait-for-3.1.0.tgz",
+      "integrity": "sha1-naVooq3aPqgXWjxD9GpTF+KMDkc=",
+      "requires": {
+        "p-timeout": "^3.0.0"
+      }
     },
     "pac-proxy-agent": {
       "version": "3.0.1",
@@ -8489,6 +8602,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npm.taobao.org/safe-json-stringify/download/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha1-NW5EvJjx+TzkXfFLzXwBzahuCv0=",
+      "optional": true
     },
     "safe-regex": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
     "egg-scripts": "^2.6.0",
     "eventsource": "^1.0.7",
     "extend2": "^1.0.0",
+    "github-data-cat": "^1.0.1",
     "lodash": "^4.17.15",
-    "node-schedule": "^1.3.2"
+    "node-schedule": "^1.3.2",
+    "p-wait-for": "^3.1.0"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.40",


### PR DESCRIPTION
Add GitHub data collector, fix #11 . 

Each Github client can call updateData() to fetch repoData. We use [github-data-cat]( https://www.npmjs.com/package/github-data-cat) to collect data, but because of the Repo data type of local and github-data-cat are different, we made a data adaptation.