### PR TITLE
fix: fix event param bug

### DIFF
--- a/app/plugin/event-manager/AppEventManager.ts
+++ b/app/plugin/event-manager/AppEventManager.ts
@@ -70,8 +70,11 @@ export class AppEventManager extends AppPluginBase<null> {
         // broadcast will send to agent and all workers
         this.app.messenger.broadcast(IPC_EVENT_NAME, p);
         // send to a random worker
-        p.type = 'worker';
-        this.app.messenger.sendRandom(IPC_EVENT_NAME, p);
+        // need to create a new param here because IPC send may async and may affect former event
+        this.app.messenger.sendRandom(IPC_EVENT_NAME, {
+          ...p,
+          type: 'worker',
+        });
         break;
       default: break;
     }


### PR DESCRIPTION
fix: fix event param bug, reuse of param p may cause former event fail because the underlying send mechanism is async and 0-copy, so we need to create a new param

fix #49 

Signed-off-by: Frankzhaopku <syzhao1988@126.com>