### PR TITLE
complete event-manager test cases and correct spelling error

### DIFF
--- a/app/plugin/event-manager/AgentEventManager.ts
+++ b/app/plugin/event-manager/AgentEventManager.ts
@@ -57,8 +57,11 @@ export class AgentEventManager extends AgentPluginBase<null> {
       case 'all':
         this.agent.messenger.sendToApp(IPC_EVENT_NAME, p);
         this.consume(className, type, param);
-        p.type = 'worker';
-        this.agent.messenger.sendRandom(IPC_EVENT_NAME, p);
+        // need to create a new param here because IPC send may async and may affect former event
+        this.agent.messenger.sendRandom(IPC_EVENT_NAME, {
+          ...p,
+          type: 'worker',
+        });
         break;
       case 'agent':
         this.consume(className, type, param);

--- a/app/plugin/scheduler-manager/AgentSchedulerManager.ts
+++ b/app/plugin/scheduler-manager/AgentSchedulerManager.ts
@@ -43,7 +43,7 @@ export class AgentSchedulerManager extends AgentPluginBase<null> {
       const job = this.workerHandlerMap.get(e.name);
       if (!job) return;
       switch (e.type) {
-        case 'cancle':
+        case 'cancel':
           job.cancel();
           this.workerHandlerMap.delete(e.name);
           break;

--- a/app/plugin/scheduler-manager/AgentWorkerJobHandler.ts
+++ b/app/plugin/scheduler-manager/AgentWorkerJobHandler.ts
@@ -44,10 +44,10 @@ export class AgentWorkerJobHandler implements ISchedulerJobHandler {
     });
   }
 
-  public cancle(): void {
+  public cancel(): void {
     this.app.event.publish('agent', SchedulerWorkerUpdateEvent, {
       name: this.innerName,
-      type: 'cancle',
+      type: 'cancel',
     });
   }
 
@@ -86,6 +86,6 @@ export class SchedulerAgentScheduleEvent {
 
 export class SchedulerWorkerUpdateEvent {
   public name: string;
-  public type: 'update' | 'cancle';
+  public type: 'update' | 'cancel';
   public time?: string;
 }

--- a/app/plugin/scheduler-manager/BasicJobHandler.ts
+++ b/app/plugin/scheduler-manager/BasicJobHandler.ts
@@ -23,7 +23,7 @@ export class BasicJobHanlder implements ISchedulerJobHandler {
     this.job = job;
   }
 
-  cancle(): void {
+  cancel(): void {
     this.job.cancel();
   }
 

--- a/app/plugin/scheduler-manager/types.ts
+++ b/app/plugin/scheduler-manager/types.ts
@@ -22,9 +22,9 @@ export type ISchedulerJobCallback = (time: Date) => void;
  */
 export interface ISchedulerJobHandler {
   /**
-   * cancle current scheduler
+   * cancel current scheduler
    */
-  cancle(): void;
+  cancel(): void;
   /**
    * reschedule the scheduler
    */

--- a/test/plugin/Util.ts
+++ b/test/plugin/Util.ts
@@ -1,8 +1,17 @@
+import { MockApplication } from 'egg-mock';
+
 // wait for milliseconds until ipc finish
 export function waitFor(milliseconds: number): Promise<void> {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        resolve();
-      }, milliseconds);
-    });
-  }
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, milliseconds);
+  });
+}
+
+// simulate ipc so that agent and app can communicate with each other
+export function initIpc(app: MockApplication, milliseconds: number = 10) {
+  process.env.SENDMESSAGE_ONE_PROCESS = 'true';
+  app.messenger.sendTo(process.pid, 'egg-pids', [ process.pid ]);
+  return waitFor(milliseconds);
+}

--- a/test/plugin/event-manager/AgentEventManager.test.ts
+++ b/test/plugin/event-manager/AgentEventManager.test.ts
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 import mock, { MockApplication } from 'egg-mock';
-import { waitFor } from '../Util';
+import { waitFor, initIpc } from '../Util';
 
 describe('AgentEventManager', () => {
   let app: MockApplication;
@@ -12,6 +12,7 @@ describe('AgentEventManager', () => {
         cache: false,
     });
     await app.ready();
+    await initIpc(app);
   });
   afterEach(() => {
     mock.restore();
@@ -22,24 +23,20 @@ describe('AgentEventManager', () => {
   }
 
   describe('publish()', () => {
-    // can't send to random
     it('should publish to a random worker', async () => {
       let count = 0;
       app.event.subscribeOne(TestEvent, async e => { count += e.num; });
       (app as any).agent.event.publish('worker', TestEvent, { num: 1 });
       await waitFor(10);
-      console.log(count);
-      // assert(count === 1);
+      assert(count === 1);
     });
 
-    // agent can't send to workers
     it('should publish to all workers', async () => {
       let count = 0;
       app.event.subscribeAll(TestEvent, async e => { count += e.num; });
       (app as any).agent.event.publish('workers', TestEvent, { num: 1 });
       await waitFor(10);
-      console.log(count);
-      // assert(count === 1);
+      assert(count === 1);
     });
 
     it('should publish to the agent itself', async () => {
@@ -50,15 +47,13 @@ describe('AgentEventManager', () => {
       assert(count === 1);
     });
 
-    // agent can't send to app correctlly
     it('should publish to all processes', async () => {
       let count = 0;
       app.event.subscribeAll(TestEvent, async e => { count += e.num; });
       (app as any).agent.event.subscribe(TestEvent, async e => { count += e.num; });
       (app as any).agent.event.publish('all', TestEvent, { num: 1 });
       await waitFor(10);
-      console.log(count);
-      // assert(count === 2);
+      assert(count === 2);
     });
   });
 


### PR DESCRIPTION
1. Add simulation method. Now `agent` and `app` in mock application can communicate correctly.

2. Correct the spelling error of `cancel` in some places. (was `cancle`)