### PR TITLE
refactor: test framework modify

### DIFF
--- a/test/plugin/Util.ts
+++ b/test/plugin/Util.ts
@@ -1,4 +1,5 @@
-import { MockApplication } from 'egg-mock';
+import mock, { MockApplication } from 'egg-mock';
+import { Application, Agent } from 'egg';
 
 // wait for milliseconds until ipc finish
 export function waitFor(milliseconds: number): Promise<void> {
@@ -14,4 +15,27 @@ export function initIpc(app: MockApplication, milliseconds: number = 10) {
   process.env.SENDMESSAGE_ONE_PROCESS = 'true';
   app.messenger.sendTo(process.pid, 'egg-pids', [ process.pid ]);
   return waitFor(milliseconds);
+}
+
+// prepare application for unit test
+export async function prepareTestApplication(): Promise<{app: Application, agent: Agent}> {
+  const app = mock.app({
+    cache: false,
+  });
+  await app.ready();
+  await initIpc(app);
+  return {
+    app,
+    agent: (app as any).agent,
+  };
+}
+
+export function testClear(app?: Application, agent?: Agent) {
+  if (app) {
+    (app.messenger as any).close();
+  }
+  if (agent) {
+    (agent.messenger as any).close();
+  }
+  mock.restore();
 }

--- a/test/plugin/event-manager/AgentEventManager.test.ts
+++ b/test/plugin/event-manager/AgentEventManager.test.ts
@@ -1,59 +1,54 @@
 'use strict';
 
 import assert from 'assert';
-import mock, { MockApplication } from 'egg-mock';
-import { waitFor, initIpc } from '../Util';
+import { waitFor, prepareTestApplication, testClear } from '../Util';
+import { Application, Agent } from 'egg';
 
 describe('AgentEventManager', () => {
-  let app: MockApplication;
-
-  beforeEach(async () => {
-    app = mock.app({
-        cache: false,
-    });
-    await app.ready();
-    await initIpc(app);
-  });
-  afterEach(() => {
-    mock.restore();
-  });
+  let app: Application;
+  let agent: Agent;
+  let count = 0;
 
   class TestEvent {
     num: number;
   }
 
-  describe('publish()', () => {
-    it('should publish to a random worker', async () => {
-      let count = 0;
-      app.event.subscribeOne(TestEvent, async e => { count += e.num; });
-      (app as any).agent.event.publish('worker', TestEvent, { num: 1 });
-      await waitFor(10);
-      assert(count === 1);
+  const func = async (e: TestEvent) => {
+    count += e.num;
+  };
+
+  const test = async (type: 'worker' | 'workers' | 'agent' | 'all', result: number) => {
+    agent.event.publish(type, TestEvent, { num: 1 });
+    await waitFor(10);
+    assert(count === result);
+  };
+
+  beforeEach(async () => {
+    ({ app, agent } = await prepareTestApplication());
+    count = 0;
+    app.event.subscribeAll(TestEvent, func);
+    app.event.subscribeOne(TestEvent, func);
+    agent.event.subscribe(TestEvent, func);
+  });
+  afterEach(() => {
+    testClear(app, agent);
+  });
+
+  describe('publish test', () => {
+    it('publish to a random worker', async () => {
+      await test('worker', 1);
     });
 
-    it('should publish to all workers', async () => {
-      let count = 0;
-      app.event.subscribeAll(TestEvent, async e => { count += e.num; });
-      (app as any).agent.event.publish('workers', TestEvent, { num: 1 });
-      await waitFor(10);
-      assert(count === 1);
+    it('publish to all workers', async () => {
+      await test('workers', 1);
     });
 
-    it('should publish to the agent itself', async () => {
-      let count = 0;
-      (app as any).agent.event.subscribe(TestEvent, async e => { count += e.num; });
-      (app as any).agent.event.publish('agent', TestEvent, { num: 1 });
-      await waitFor(10);
-      assert(count === 1);
+    it('publish to the agent itself', async () => {
+      await test('agent', 1);
     });
 
-    it('should publish to all processes', async () => {
-      let count = 0;
-      app.event.subscribeAll(TestEvent, async e => { count += e.num; });
-      (app as any).agent.event.subscribe(TestEvent, async e => { count += e.num; });
-      (app as any).agent.event.publish('all', TestEvent, { num: 1 });
-      await waitFor(10);
-      assert(count === 2);
+    it('publish to all processes', async () => {
+      await test('all', 3);
     });
   });
 

--- a/test/plugin/event-manager/AppEventManager.test.ts
+++ b/test/plugin/event-manager/AppEventManager.test.ts
@@ -1,61 +1,54 @@
 'use strict';
 
 import assert from 'assert';
-import mock, { MockApplication } from 'egg-mock';
-import { waitFor, initIpc } from '../Util';
+import { waitFor, prepareTestApplication, testClear } from '../Util';
+import { Application, Agent } from 'egg';
 
 describe('AppEventManager', () => {
-  let app: MockApplication;
-
-  beforeEach(async () => {
-    app = mock.app({
-        cache: false,
-    });
-    await app.ready();
-    await initIpc(app);
-  });
-  afterEach(() => {
-    mock.restore();
-  });
+  let app: Application;
+  let agent: Agent;
+  let count = 0;
 
   class TestEvent {
     num: number;
   }
 
-  describe('publish()', () => {
-    it('should publish to a random worker', async () => {
-      let count = 0;
-      app.event.subscribeOne(TestEvent, async e => { count += e.num; });
-      app.event.subscribeAll(TestEvent, async e => { count += e.num; });
-      (app as any).agent.event.subscribe(TestEvent, async e => { count += e.num; });
-      app.event.publish('worker', TestEvent, { num: 1 });
-      await waitFor(10);
-      assert(count === 1);
+  const func = async (e: TestEvent) => {
+    count += e.num;
+  };
+
+  const test = async (type: 'worker' | 'workers' | 'agent' | 'all', result: number) => {
+    agent.event.publish(type, TestEvent, { num: 1 });
+    await waitFor(10);
+    assert(count === result);
+  };
+
+  beforeEach(async () => {
+    ({ app, agent } = await prepareTestApplication());
+    count = 0;
+    app.event.subscribeAll(TestEvent, func);
+    app.event.subscribeOne(TestEvent, func);
+    agent.event.subscribe(TestEvent, func);
+  });
+  afterEach(() => {
+    testClear(app, agent);
+  });
+
+  describe('publish test', () => {
+    it('publish to a random worker', async () => {
+      await test('worker', 1);
     });
 
     it('should publish to all workers', async () => {
-      let count = 0;
-      app.event.subscribeAll(TestEvent, async e => { count += e.num; });
-      app.event.publish('workers', TestEvent, { num: 1 });
-      await waitFor(10);
-      assert(count === 1);
+      await test('workers', 1);
     });
 
     it('should publish to the agent', async () => {
-      let count = 0;
-      (app as any).agent.event.subscribe(TestEvent, async e => { count += e.num; });
-      app.event.publish('agent', TestEvent, { num: 1 });
-      await waitFor(10);
-      assert(count === 1);
+      await test('agent', 1);
     });
 
     it('should publish to all processes', async () => {
-      let count = 0;
-      app.event.subscribeAll(TestEvent, async e => { count += e.num; });
-      (app as any).agent.event.subscribe(TestEvent, async e => { count += e.num; });
-      app.event.publish('all', TestEvent, { num: 1 });
-      await waitFor(10);
-      assert(count === 2);
+      await test('all', 3);
     });
   });
 


### PR DESCRIPTION
Refactor test framework, offer more convenient functions to mock new `app` and `agent`, and also `testClear` function which will remove messenger listeners to avoid multiple message in multiple test cases. Related to #20 

Signed-off-by: Frankzhaopku <syzhao1988@126.com>