### PR TITLE
test: add test for utils

### DIFF
--- a/test/plugin/basic/Utils.test.ts
+++ b/test/plugin/basic/Utils.test.ts
@@ -1,0 +1,77 @@
+'use strict';
+
+import assert from 'assert';
+import * as Utils from '../../../app/basic/Utils';
+
+describe('Utils', () => {
+
+  describe('parseRepoName', () => {
+    it('parse a valid name', async () => {
+      const owner = 'owner';
+      const repo = 'repo';
+      const { owner: o, repo: r } = Utils.parseRepoName(`${owner}/${repo}`);
+      assert(o === owner && r === repo);
+    });
+
+    it('parse a name with no slash', async () => {
+      const { owner, repo } = Utils.parseRepoName('name');
+      assert(owner === '' && repo === '');
+    });
+
+    it('parse a name with multiple slash', async () => {
+      const { owner, repo } = Utils.parseRepoName('a/b/c');
+      assert(owner === '' && repo === '');
+    });
+  });
+
+  describe('getRepoFullName', () => {
+    it('getRepoFullName', () => {
+      const name = Utils.getRepoFullName('a', 'b');
+      assert(name === 'a/b');
+    });
+  });
+
+  describe('AutoCreateMap', () => {
+    let map: Utils.AutoCreateMap<string, string[]>;
+
+    beforeEach(() => {
+      map = new Utils.AutoCreateMap(() => []);
+    });
+
+    it('get exist value', () => {
+      map.set('key', [ 'value1', 'value2' ]);
+      const v = map.get('key');
+      assert(v.length === 2);
+    });
+
+    it('get non-exist value with default generator', () => {
+      const v = map.get('key');
+      assert(v.length === 0);
+    });
+
+    it('get non-exist value with custom generator', () => {
+      const v = map.get('key', () => [ 'value1', 'value2' ]);
+      assert(v.length === 2);
+    });
+  });
+
+  describe('customizerMerge', () => {
+
+  });
+
+  describe('parseDate', () => {
+
+  });
+
+  describe('waitUntil', () => {
+    it('should wait until condition match', async () => {
+      let condition = false;
+      setTimeout(() => {
+        condition = true;
+      }, 5);
+      await Utils.waitUntil(() => condition, { interval: 2 });
+      assert(condition);
+    });
+  });
+
+});

--- a/test/plugin/event-manager/EventManager.test.ts
+++ b/test/plugin/event-manager/EventManager.test.ts
@@ -33,7 +33,7 @@ describe('EventManager', () => {
 
   const test = async (sender: any, type: 'worker' | 'workers' | 'agent' | 'all', ...types: consumeType[]) => {
     sender.event.publish(type, TestEvent, {});
-    await waitFor(10);
+    await waitFor(2);
     assert(count === getScore(...types));
   };
 


### PR DESCRIPTION
test: add test for utils, `customizerMerge` and `parseDate` keeps empty.

Also shorten the `waitFor` time to reduce test time.

Signed-off-by: Frankzhaopku <syzhao1988@126.com>