### PR TITLE
fix: fix app send random

### DIFF
--- a/app/plugin/event-manager/AgentEventManager.ts
+++ b/app/plugin/event-manager/AgentEventManager.ts
@@ -81,6 +81,14 @@ export class AgentEventManager extends AgentPluginBase<null> {
           this.logger.error(`Error processing handlers, className=${className}, e=`, e);
         }
         break;
+      case 'worker':
+        // if worker, means need to send to a random worker
+        this.agent.messenger.sendRandom(IPC_EVENT_NAME, {
+          className,
+          type,
+          payload: param,
+        });
+        break;
       default:
         break;
     }

--- a/app/plugin/event-manager/AppEventManager.ts
+++ b/app/plugin/event-manager/AppEventManager.ts
@@ -71,7 +71,7 @@ export class AppEventManager extends AppPluginBase<null> {
         this.app.messenger.broadcast(IPC_EVENT_NAME, p);
         // send to a random worker
         // need to create a new param here because IPC send may async and may affect former event
-        this.app.messenger.sendRandom(IPC_EVENT_NAME, {
+        this.app.messenger.sendToAgent(IPC_EVENT_NAME, {
           ...p,
           type: 'worker',
         });


### PR DESCRIPTION
fix: fix app send random
`app.messenger.sendRandom` is not implemented in egg, so the event actually lost, need to send to agent and then agent send `worker` type event to random worker.

Signed-off-by: Frankzhaopku <syzhao1988@126.com>