### PR TITLE
Test: add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,55 @@
+pipeline {
+    agent {
+        docker {
+            image 'node:10'
+            args '-u root'
+        }
+    }
+    options {
+        timeout(time: 30, unit: 'MINUTES') 
+    }
+    stages {
+        stage('Install') {
+            steps{
+                sh 'cp -R $PWD/* /home && cd /home'
+                sh 'npm install'
+            }
+        }
+        stage('Test') {
+            steps {
+                sh 'npm run lint'
+                sh 'npm run test-local'
+            }
+        }
+        stage('Deploy') {
+            steps {
+                sh 'printenv'
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                def buildResult = "${currentBuild.currentResult}".toLowerCase()
+                
+                def myColor = "danger"
+                if (buildResult == "success") {
+                    myColor = "good"
+                }
+
+                def commitId = "${env.GIT_COMMIT}".substring(0, 7)
+
+                def attachments = [
+                    [
+                        text: """
+                        Project `${env.JOB_NAME}` ${buildResult} build (<${env.BUILD_URL}|#${currentBuild.number}>) for commit (<${env.GIT_URL}|${commitId}>) on branch `${env.BRANCH_NAME}`\nExecution time: ${currentBuild.durationString}\nMessage: The build ${buildResult}.
+                        """,
+                        fallback: "Jenkins pipeline result",
+                        color: myColor
+                    ]
+                ]
+                slackSend(channel: '#cicd', attachments: attachments)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Jenkinsfile mentioned in #51 

We have built our own CI platform based on Jenkins and bound the project to Jenkins. After adding Jenkinsfile, every Push and PR event will trigger Jenkins to execute Pipeline. The tasks currently defined by Pipeline are:
- npm install
- npm run lint
- npm run test
- send the result to slack

Pipeline execution time is limited to 30 minutes, all tasks are executed in the container, and the container is automatically cleaned up after the execution. Execution results will also be displayed in the Github repository.

