### PR TITLE
test: add unit test config to avoid console log

### DIFF
--- a/config/config.unittest.ts
+++ b/config/config.unittest.ts
@@ -1,0 +1,25 @@
+// Copyright 2019 Xlab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.import { EggAppConfig, PowerPartial } from 'egg';
+
+import { EggAppConfig, PowerPartial } from 'egg';
+
+export default () => {
+  const config: PowerPartial<EggAppConfig> = {};
+
+  config.logger = {
+    consoleLevel: 'NONE',
+  };
+
+  return config;
+};


### PR DESCRIPTION
Add a `config.unittest.ts`, which is the config for test, set logger `consoleLevel` to `NONE` to disable logger output.

Signed-off-by: Frankzhaopku <syzhao1988@126.com>