### PR TITLE
fix: lua not support async functions right now

### DIFF
--- a/app/lua-vm/LuaVm.ts
+++ b/app/lua-vm/LuaVm.ts
@@ -64,13 +64,13 @@ export class LuaVm {
 
   public set(key: string, value: any, target?: any): this {
     if (typeof value === 'function') {
-      value = this.wrapFunc(value, target);
+      value = this.wrapFunc(key, value, target);
     }
     this.ctx.set(key, value);
     return this;
   }
 
-  private wrapFunc(func: (...args: any[]) => any, target?: any): any {
+  private wrapFunc(key: string, func: (...args: any[]) => any, target?: any): any {
     const wrapped = (): any => {
       // call in ts
       const nArgs = lua.lua_gettop(this.L);
@@ -83,6 +83,8 @@ export class LuaVm {
       // set return value
       return this.pushStackValue(res);
     };
+    // save key as function name for debugging use
+    Object.defineProperty(func, 'name', { value: key });
     return wrapped;
   }
 

--- a/app/lua-vm/decorators.ts
+++ b/app/lua-vm/decorators.ts
@@ -25,9 +25,9 @@ export function luaMethod(): MethodDecorator {
     if (typeof obj.setInjectFunction === 'function' && key.startsWith(LuaFunctionPrefix)) {
       // replace the actual function, auto try catch to avoid Lua failure when ts throws
       const fn = descriptor.value;
-      descriptor.value = async function (...args: any[]) {
+      descriptor.value = function (...args: any[]) {  // not support async call right now
         try {
-          return await fn.apply(this, args);
+          return fn.apply(this, args);
         } catch (e) {
           console.log(`Error exec lua-ts function ${key}, e=${e.message ? e.message : e}`);
         }


### PR DESCRIPTION
If the auto catch module wrap the function as an async function, the return value will be a `Promise`, then not support to push it into Lua stack.

Not support async calls right now and set func name for debugging.

Signed-off-by: Frankzhaopku <syzhao1988@126.com>