### PR TITLE
fix: remove community link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ For more details, please refer to [architecture](./docs/ARCHITECTURE.md).
 
 Hypertrons also use hypertrons(play as menbotics) to manage community, the community roles can be found in [config file](./.github/hypertrons.json).
 
-![community](http://api.hypertrons.io/docs/github/oss-mentor-bot/hypertrons/community.svg)
-
 ## Support
 
 If you have any questions or feature requests, please feel free to submit an issue.


### PR DESCRIPTION
The svg file from the server can not be correctly rendered by GitHub due to security reasons, the external image urls are banned so the avatars can not be displayed.

Remove the link for now and will find way around later.

Signed-off-by: Frankzhaopku <syzhao1988@126.com>