### PR TITLE
fix: embedded table transfer bug

### DIFF
--- a/app/lua-vm/LuaVm.ts
+++ b/app/lua-vm/LuaVm.ts
@@ -89,6 +89,12 @@ export class LuaVm {
   }
 
   private getStackValue(index: number): any {
+    // The later check is because of the bug of fengari(https://github.com/fengari-lua/fengari/issues/175)
+    // will track this later
+    if (index < 0 && lua.lua_gettop(this.L) + index + 1 !== 0) {
+      // change index to positive number
+      index = lua.lua_gettop(this.L) + index + 1;
+    }
     const type = this.getStackType(index);
     switch (type) {
       case 'number':

--- a/test/lua-vm/LuaVm.test.ts
+++ b/test/lua-vm/LuaVm.test.ts
@@ -150,6 +150,24 @@ return func(a, add(b, c), d)
     assert(res === a - b - c - d);
   });
 
+  it('Should support embedded object', () => {
+    let res: any = {};
+    const set = (obj: any) => {
+      res = obj;
+    };
+    luaVm.set('set', set);
+    luaVm.run(`
+local t = {
+  ['a'] = 'test',
+  ['d'] = {
+    ['e'] = -1
+  }
+}
+set(t)
+`);
+    assert(res.a === 'test' && res.d.e === -1);
+  });
+
   it('Should get value inside a map', () => {
     const a = 2, b = 3, c = 4;
     let res = 0;


### PR DESCRIPTION
The recursive `getValue` will not get the correct stack position if the index is negative, so transfer the negative index to positive index before processing.

But due a possible bug of fengari(https://github.com/fengari-lua/fengari/issues/175), an extra check is added into the if statement(lua.lua_gettop(this.L) + index + 1 !== 0), now the test case passed as expected, but will check this later.

fix #215 

Signed-off-by: Frankzhaopku <syzhao1988@126.com>