### PR TITLE
refactor: add check statement before get config in lua, #220

### DIFF
--- a/app/component/auto_label/index.lua
+++ b/app/component/auto_label/index.lua
@@ -34,6 +34,10 @@ local autoLabel = function (e)
   end
 end
 
-for i = 1, #compConfig.events do
-  on(compConfig.events[i], autoLabel)
+if (config['label_setup'] ~= nil and config['label_setup'].labels ~= nil) then
+  for i = 1, #compConfig.events do
+    on(compConfig.events[i], autoLabel)
+  end
+else 
+  log("Not set label_setup.labels in config, skip " .. compName)
 end

--- a/app/component/auto_merge/index.lua
+++ b/app/component/auto_merge/index.lua
@@ -13,18 +13,24 @@
 -- limitations under the License.
 
 -- Auto merge pull by approve command
-sched(compConfig.schedName, compConfig.sched, function ()
-  local data = getData()
-  if (data == nil) then -- data not ready yet
-    return
-  end
-  for i= 1, #data.pulls do
-    local pull = data.pulls[i]
-    -- if the pull is still open and have config['approve'].label (default: pull/approved), try merge it
-    if (pull.closedAt == nil and arrayContains(pull.labels, function (l)
-      return l == config['approve'].label
-    end)) then
-      merge(pull.number)
+
+if (config['approve'] ~= nil and config['approve'].label ~= nil) then 
+  sched(compConfig.schedName, compConfig.sched, function ()
+    local data = getData()
+    if (data == nil) then -- data not ready yet
+      return
     end
-  end
-end)
+    for i= 1, #data.pulls do
+      local pull = data.pulls[i]
+      -- if the pull is still open and have config['approve'].label (default: pull/approved), try merge it
+      if (pull.closedAt == nil and arrayContains(pull.labels, function (l)
+        return l == config['approve'].label
+      end)) then
+        merge(pull.number)
+      end
+    end
+  end)
+else
+  log("Not set approve.label in config, skip " .. compName)
+end
+

--- a/app/component/difficulty/index.lua
+++ b/app/component/difficulty/index.lua
@@ -13,18 +13,22 @@
 -- limitations under the License.
 
 -- Difficuty command
-on('CommandEvent', function (e)
-  if (e.command == compConfig.command) then
-    if (#e.params ~= 1) then
-      return
+if (config['label_setup'] ~= nil and config['label_setup'].labels ~= nil) then
+  on('CommandEvent', function (e)
+    if (e.command == compConfig.command) then
+      if (#e.params ~= 1) then
+        return
+      end
+      local level = e.params[1]
+      local label = 'difficulty/' .. level
+      local labels = config['label_setup'].labels
+      if (arrayContains(labels, function (l)
+        return l.name == label
+      end)) then
+        addLabels(e.number, { label })
+      end
     end
-    local level = e.params[1]
-    local label = 'difficulty/' .. level
-    local labels = config['label_setup'].labels
-    if (arrayContains(labels, function (l)
-      return l.name == label
-    end)) then
-      addLabels(e.number, { label })
-    end
-  end
-end)
+  end)
+else
+  log("Not set label_setup.labels in config, skip " .. compName)
+end

--- a/app/utils/md-lint/index.ts
+++ b/app/utils/md-lint/index.ts
@@ -200,7 +200,7 @@ function getMarkdownLint() {
     // http://www.cirosantilli.com/markdown-style-guide/#email-automatic-links.
     // Not checked.
 
-    require('remark-lint-no-dead-urls'),
+    [ require('remark-lint-no-dead-urls'), { skipOffline: true }],
     require('remark-lint-final-newline'),
     require('remark-lint-list-item-bullet-indent'),
     require('remark-lint-no-duplicate-definitions'),

--- a/test/component/LuaTestUtil.ts
+++ b/test/component/LuaTestUtil.ts
@@ -111,6 +111,7 @@ export async function prepareLuaTest(path: string, opt?: { customConfig?: any, i
 
   luaVm.set('config', hypertronsConfig);
   luaVm.set('compConfig', compConfig);
+  luaVm.set('compName', compName);
   luaVm.run(luaContent);
 
   return luaTestVm;

--- a/test/component/difficulty/difficulty.test.ts
+++ b/test/component/difficulty/difficulty.test.ts
@@ -17,7 +17,7 @@
 import assert from 'power-assert';
 import { prepareLuaTest } from '../LuaTestUtil';
 
-describe('approve component', () => {
+describe('difficulty component', () => {
   let luaVmWrapper;
 
   before(async () => {
@@ -27,9 +27,9 @@ describe('approve component', () => {
     luaVmWrapper.clean();
   });
 
-  describe('exec approve command', () => {
+  describe('exec difficulty command', () => {
 
-    it('add approve label', async () => {
+    it('add difficulty label', async () => {
       const result = luaVmWrapper.publish('CommandEvent', {
         number: 42,
         command: '/difficulty',


### PR DESCRIPTION
Add check statement before use config in lua script, fix #220 

Changelog:

- auto_label: check `config[label_setup].labels`
- auto_merge: check `config['approve'].label`, 
- difficulty: check `config['label_setup'].labels`,


Signed-off-by: WuShaoling <wsl6@outlook.com>