### PR TITLE
fix: merge config keep origin data

### DIFF
--- a/app/basic/HostingPlatform/HostingClientService/ConfigService.ts
+++ b/app/basic/HostingPlatform/HostingClientService/ConfigService.ts
@@ -154,7 +154,7 @@ export class ConfigService<TConfig extends HostingConfigBase, TRawClient>
   }
 
   private async mergeConfig() {
-    const mergeConfig = customizerMerge({}, ...Object.values(this.rawData.config).map(v => v));
+    const mergeConfig = customizerMerge(...Object.values(this.rawData.config).map(v => v));
     const defaultConfig = await this.client.getHostingBase().compService.getDefaultConfig(mergeConfig);
     this.config = customizerMergeWithType(defaultConfig, mergeConfig);
   }

--- a/app/basic/Utils.ts
+++ b/app/basic/Utils.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { mergeWith, isArray } from 'lodash';
+import { mergeWith, isArray, cloneDeep } from 'lodash';
 import waitFor from 'p-wait-for';
 import { EggLogger } from 'egg-logger';
 import { pope } from 'pope';
@@ -63,46 +63,46 @@ export class AutoCreateMap<K, V> extends Map<K, V> {
 
 export function customizerMerge(...objs: any[]): any {
   if (!objs || objs.length === 0) return {};
+  const res = cloneDeep(objs[0]);
   try {
     for (let i = 1; i < objs.length; i++) {
-      mergeWith(objs[0], objs[i], (objValue: any, srcValue: any, _: string) => {
+      mergeWith(res, objs[i], (objValue: any, srcValue: any, _: string) => {
         if (typeof objValue !== typeof srcValue) return srcValue !== undefined ? srcValue : objValue;
         if (isArray(srcValue)) {
           if (srcValue[0] && srcValue[0].__merge__ === true) {
-            (srcValue as any[]).shift();
-            return objValue.concat(srcValue.filter(v => !objValue.includes(v)));
+            return objValue.concat(srcValue.slice(1).filter(v => !objValue.includes(v)));
           }
           return srcValue;
         }
       });
     }
-    return objs[0];
+    return res;
   } catch (err) {
-    return objs[0];
+    return res;
   }
 }
 
 export function customizerMergeWithType(...objs: any[]): any {
   if (!objs || objs.length === 0) return {};
+  const res = cloneDeep(objs[0]);
   try {
     for (let i = 1; i < objs.length; i++) {
-      mergeWith(objs[0], objs[i], (objValue: any, srcValue: any, _: string) => {
+      mergeWith(res, objs[i], (objValue: any, srcValue: any, _: string) => {
         if (typeof objValue !== typeof srcValue) {
           return objValue ? objValue : srcValue;
         }
         if (isArray(srcValue)) {
           if (srcValue[0] && srcValue[0].__merge__ === true) {
-            (srcValue as any[]).shift();
-            return objValue.concat(srcValue.filter(v => !objValue.includes(v)));
+            return objValue.concat(srcValue.slice(1).filter(v => !objValue.includes(v)));
           } else {
             return srcValue;
           }
         }
       });
     }
-    return objs[0];
+    return res;
   } catch (err) {
-    return objs[0];
+    return res;
   }
 }
 


### PR DESCRIPTION
In `app/basic/Utils.ts`, `customizerMerge()` and `customizerMergeWithType()` will modify both target object and source object. This commit change it, now the method will not change any objects and return a new one.

Specifically, if source config's array contains element `__merge__`, it will be discarded. Thus config will not be able to merge next time.

In [last PR](https://github.com/hypertrons/hypertrons/pull/247/files), `mergeConfig()` is called twice. But at the second time, config will not merge.

``` ts
export function customizerMerge(...objs: any[]): any {
  if (!objs || objs.length === 0) return {};
  try {
    const res = cloneDeep(objs[0]);
    for (let i = 1; i < objs.length; i++) {
      mergeWith(res, objs[i], (objValue: any, srcValue: any, _: string) => {
        if (typeof objValue !== typeof srcValue) return srcValue !== undefined ? srcValue : objValue;
        if (isArray(srcValue)) {
          if (srcValue[0] && srcValue[0].__merge__ === true) {
            // next line change the source value
            (srcValue as any[]).shift();
            // next line change the target value
            return objValue.concat(srcValue.filter(v => !objValue.includes(v)));
          }
          return srcValue;
        }
      });
    }
    return res;
  } catch (err) {
    return objs[0];
  }
}
```

Signed-off-by: pantang <729618421@qq.com>