### PR TITLE
feature: does not remind repliers of issues that contains specifc labels

### DIFF
--- a/app/component/issue_reminder/config.ts
+++ b/app/component/issue_reminder/config.ts
@@ -44,4 +44,10 @@ export default class Config {
   })
   message: string;
 
+  @configProp({
+    description: 'Ignore issues with specific labels',
+    defaultValue: defaultConfig.ignore,
+  })
+  ignore: string[];
+
 }

--- a/app/component/issue_reminder/defaultConfig.ts
+++ b/app/component/issue_reminder/defaultConfig.ts
@@ -19,6 +19,7 @@ const defaultConfig: Config = {
   sched: '0 0 9 * * *',
   reminderRole: 'replier',
   message: 'This issue has not been replied for 24 hours, please pay attention to this issue: ',
+  ignore: [ 'weekly-report' ],
 };
 
 export default defaultConfig;

--- a/app/component/issue_reminder/index.lua
+++ b/app/component/issue_reminder/index.lua
@@ -19,6 +19,7 @@ sched(compConfig.schedName, compConfig.sched, function ()
     return
   end
   local users = getRoles(compConfig.reminderRole)
+  local labels = compConfig.ignore
   if (#users == 0) then
     return
   end
@@ -29,10 +30,12 @@ sched(compConfig.schedName, compConfig.sched, function ()
   for i= 1, #data.issues do
     local issue = data.issues[i]
     -- filter rule: 1. still open 2. has no comments 3. opened before 24 hours
-    -- 4. issue author is not a bot 5. issue author is not a replier.
-    -- GitHub bots' name end with '[bot]'. Other platforms could name bot in this way.
+    -- 4. issue does not contains ignore labels 5. issue author is not a replier.
     if (issue.closedAt == nil and #issue.comments == 0 and toNow(issue.createdAt) > 24 * 60 * 60 * 1000
-        and string.find(issue.author, '%[bot%]', #issue.author-4) == nil
+        and not arrayContains(issue.labels, 
+        function (l1) 
+          return arrayContains(labels, function (l2) return l2 == l1 end)
+        end)
         and not arrayContains(users, function (u) return u == issue.author end)) then
       addIssueComment(issue.number, msg)
     end

--- a/test/component/issue_reminder/issue_reminder.test.ts
+++ b/test/component/issue_reminder/issue_reminder.test.ts
@@ -31,6 +31,7 @@ describe('issue_reminder component', () => {
             createdAt: 0,
             closedAt: null,
             comments: [],
+            labels: [],
           },
           // should not reply closed issue
           {
@@ -39,6 +40,7 @@ describe('issue_reminder component', () => {
             createdAt: 0,
             closedAt: 0,
             comments: [],
+            labels: [],
           },
           // should not reply commented issue
           {
@@ -51,6 +53,7 @@ describe('issue_reminder component', () => {
                 id: 1,
               },
             ],
+            labels: [],
           },
           // should not reply issue created within a day
           {
@@ -59,6 +62,7 @@ describe('issue_reminder component', () => {
             createdAt: new Date().getTime(),
             closedAt: null,
             comments: [],
+            labels: [],
           },
           // should not reply issue created by repliers
           {
@@ -67,6 +71,7 @@ describe('issue_reminder component', () => {
             createdAt: 0,
             closedAt: null,
             comments: [],
+            labels: [],
           },
           // should reply this
           {
@@ -75,6 +80,16 @@ describe('issue_reminder component', () => {
             createdAt: 0,
             closedAt: null,
             comments: [],
+            labels: [],
+          },
+          // should not reply issue that contains specific labels
+          {
+            author: 'author',
+            number: 7,
+            createdAt: 0,
+            closedAt: null,
+            comments: [],
+            labels: [ 'bug', 'weekly-report' ],
           },
         ],
       })).set('getRoles', () => [


### PR DESCRIPTION
fix #234 

Add an attribute `ignore` for component `issue_reminder`. Now hypertrons will not reply issues which contains ignored labels. 

Signed-off-by: pantang <729618421@qq.com>