### PR TITLE
refactor: update the definition of issue_reminder config

### DIFF
--- a/app/component/issue_reminder/config.ts
+++ b/app/component/issue_reminder/config.ts
@@ -46,6 +46,8 @@ export default class Config {
 
   @configProp({
     description: 'Ignore issues with specific labels',
+    type: 'array',
+    arrayType: 'string',
     defaultValue: defaultConfig.ignore,
   })
   ignore: string[];


### PR DESCRIPTION
fix #261 

Improve the definition of issue config, if do not add `type` and `arrayType`, the following error will be reported:

```
2020-02-20 12:31:18,798 WARN 84413 [host-github-component-service] Error loading config of issue_reminder, e= Error: Config type for ignore is not valid with empty array type
    at /Users/wsl/Projects/hypertrons/hypertrons/app/config-generator/decorators.ts:97:15
    at DecorateProperty (/Users/wsl/Projects/hypertrons/hypertrons/node_modules/reflect-metadata/Reflect.js:553:33)
    at Object.decorate (/Users/wsl/Projects/hypertrons/hypertrons/node_modules/reflect-metadata/Reflect.js:123:24)
    at Object.__decorate (/Users/wsl/Projects/hypertrons/hypertrons/node_modules/tslib/tslib.js:92:96)
    at Object.<anonymous> (/Users/wsl/Projects/hypertrons/hypertrons/app/component/issue_reminder/config.ts:51:3)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Module.m._compile (/Users/wsl/Projects/hypertrons/hypertrons/node_modules/ts-node/src/index.ts:439:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/wsl/Projects/hypertrons/hypertrons/node_modules/ts-node/src/index.ts:442:12)
    at Module.load (internal/modules/cjs/loader.js:815:32)
```

then causes the Lua component to fail to load.

Signed-off-by: WuShaoling <wsl6@outlook.com>