### PR TITLE
docs: add ci badge into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hypertrons
 
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3722/badge)](https://bestpractices.coreinfrastructure.org/projects/3722)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3722/badge)](https://bestpractices.coreinfrastructure.org/projects/3722) ![Hypertrons CI](https://github.com/hypertrons/hypertrons/workflows/Hypertrons%20CI/badge.svg?branch=master)
 
 Hypertrons is an open source robot hosting platform which supports [GitHub](https://www.github.com) and [GitLab](https://www.gitlab.com).
 


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

Add GitHub actions CI badge into README