### PR TITLE
refactor: fix configuration update bug, fix add repo bug

### DIFF
--- a/app/basic/HostingPlatform/HostingClientService/ConfigService.ts
+++ b/app/basic/HostingPlatform/HostingClientService/ConfigService.ts
@@ -81,9 +81,11 @@ export class ConfigService<TConfig extends HostingConfigBase, TRawClient>
             this.rawData.luaScript[key] = e.rawData.luaScript[key];
           }
         });
-        if (needUpdateLuaScript) await this.mergeLuaScript();
       }
-      if (needUpdateConfig || needUpdateLuaScript) this.client.onConfigLoaded();
+      if (needUpdateConfig || needUpdateLuaScript) {
+        await this.mergeLuaScript();
+        this.client.onConfigLoaded();
+      }
     });
 
     this.client.eventService.subscribeOne(HostingClientSyncConfigEvent, async e => this.syncData(e.status));

--- a/app/plugin/github/GitHubApp.ts
+++ b/app/plugin/github/GitHubApp.ts
@@ -147,7 +147,7 @@ export class GitHubApp extends HostingBase<GitHubConfig, GitHubClient, Octokit> 
         this.app.event.publish('all', HostingPlatformRepoAddedEvent, {
           id: this.id,
           fullName: r.full_name,
-          payload: r.id,
+          payload: e.payload.installation.id,
         });
       });
     });
@@ -156,7 +156,7 @@ export class GitHubApp extends HostingBase<GitHubConfig, GitHubClient, Octokit> 
         this.app.event.publish('all', HostingPlatformRepoAddedEvent, {
           id: this.id,
           fullName: r.full_name,
-          payload: r.id,
+          payload: e.payload.installation.id,
         });
       });
     });

--- a/test/plugin/github/GitHubApp.test.ts
+++ b/test/plugin/github/GitHubApp.test.ts
@@ -46,6 +46,7 @@ describe('GitHubApp', () => {
 
     // send created webhooks and check client
     await sendToWebhooks(app, 'installation.created', {
+      installation: { id: 1 },
       repositories: [
         {
           id: 2,
@@ -87,6 +88,7 @@ describe('GitHubApp', () => {
 
     // send created webhooks and check client
     await sendToWebhooks(app, 'installation_repositories.added', {
+      installation: { id: 1 },
       repositories_added: [
         {
           id: 2,


### PR DESCRIPTION
- Fix: Lua script is empty after the configuration updated.
- Fix: After receiving the GitHub `installation.created` event and `installation_repositories.added` event, the payload should be `event.payload.installation.id`, rather than `repositorie.id`.


Signed-off-by: WuShaoling <wsl6@outlook.com>