### PR TITLE
refactor: format repoData after receive event

### DIFF
--- a/app/basic/DataTypes.ts
+++ b/app/basic/DataTypes.ts
@@ -37,7 +37,7 @@ export interface Repo {
   license: string | null;
   codeOfConduct: string | null;
   createdAt: Date;
-  updatedAt: Date;
+  updatedAt: Date | null;
   pushedAt: Date | null;
   isFork: boolean;
   description: string | null;
@@ -70,7 +70,7 @@ export interface Issue {
   author: string;
   number: number;
   createdAt: Date;
-  updatedAt: Date;
+  updatedAt: Date | null;
   closedAt: Date | null;
   title: string;
   body: string;

--- a/app/basic/HostingPlatform/HostingClientService/RepoDataService.ts
+++ b/app/basic/HostingPlatform/HostingClientService/RepoDataService.ts
@@ -21,7 +21,7 @@ import {
 import { HostingClientRepoDataInitedEvent } from '../event';
 import { ClientServiceBase } from './ClientServiceBase';
 import { Application } from 'egg';
-import { waitUntil } from '../../Utils';
+import { waitUntil, ParseDate } from '../../Utils';
 
 export class RepoDataService<TConfig extends HostingConfigBase, TRawClient> extends ClientServiceBase<TConfig, TRawClient> {
 
@@ -56,6 +56,7 @@ export class RepoDataService<TConfig extends HostingConfigBase, TRawClient> exte
     this.client.eventService.subscribeAll(HostingClientRepoDataInitedEvent, async e => {
       this.logger.info('Repo data inited, update local data.');
       this.repoData = e.repoData;
+      this.formatRepoData();
     });
   }
 
@@ -169,6 +170,32 @@ export class RepoDataService<TConfig extends HostingConfigBase, TRawClient> exte
         pull.comments[index] = comment;
       }
     }
+  }
+
+  private formatRepoData(): void {
+    this.repoData.ownerInfo.createdAt = ParseDate(this.repoData.ownerInfo.createdAt as any);
+
+    this.repoData.createdAt = ParseDate(this.repoData.createdAt as any) as any;
+    this.repoData.updatedAt = ParseDate(this.repoData.updatedAt as any);
+    this.repoData.pushedAt = ParseDate(this.repoData.pushedAt as any);
+
+    this.repoData.issues.forEach(issue => {
+      issue.closedAt = ParseDate(issue.closedAt as any);
+      issue.createdAt = ParseDate(issue.createdAt as any) as any;
+      issue.updatedAt = ParseDate(issue.updatedAt as any);
+
+      issue.comments.forEach(c => c.createdAt = ParseDate(c.createdAt as any) as any);
+    });
+
+    this.repoData.pulls.forEach(pull => {
+      pull.createdAt = ParseDate(pull.createdAt as any) as any;
+      pull.updatedAt = ParseDate(pull.updatedAt as any) as any;
+      pull.closedAt = ParseDate(pull.closedAt as any);
+      pull.mergedAt = ParseDate(pull.mergedAt as any);
+
+      pull.comments.forEach(c => c.createdAt = ParseDate(c.createdAt as any) as any);
+      pull.reviewComments.forEach(rc => rc.createdAt = ParseDate(rc.createdAt as any) as any);
+    });
   }
 
 }

--- a/app/basic/HostingPlatform/event.ts
+++ b/app/basic/HostingPlatform/event.ts
@@ -14,6 +14,7 @@
 
 import { RepoEventBase } from '../../plugin/event-manager/events';
 import { RawDataStatus, RawData } from './HostingClientService/ConfigService';
+import { Repo } from '../DataTypes';
 export type HostingPlatformTypes = 'github' | 'gitlab' | 'gitee';
 
 // Hosting platform events
@@ -66,5 +67,5 @@ export class HostingClientConfigInitedEvent extends RepoEventBase {
 }
 
 export class HostingClientRepoDataInitedEvent extends RepoEventBase {
-  repoData: any;
+  repoData: Repo;
 }


### PR DESCRIPTION
Format repoData after receiving `HostingClientRepoDataInitedEvent`, fix #272.

For the RepoData module, the current strategy is that only one worker fetches the remote repo data, and then synchronize the data to other workers through the event mechanism. Before sending the event, the object will be serialized. After receiving the data, the type of createdAt/updatedAt ... changed from Date(object) to String, which caused errors in date comparison.

Signed-off-by: WuShaoling <wsl6@outlook.com>