### PR TITLE
fix(ci): add timeout option to ci manager

### DIFF
--- a/app/component/ci/config.ts
+++ b/app/component/ci/config.ts
@@ -75,6 +75,13 @@ export class JenkinsConfig {
     defaultValue: jenkinsDefaultConfig.repoToJobMap,
   })
   repoToJobMap: RepoJobMap[];
+
+  @configProp({
+    description: 'Jenkins request timeout',
+    type: 'number',
+    defaultValue: jenkinsDefaultConfig.timeout,
+  })
+  timeout: number;
 }
 
 /**

--- a/app/component/ci/defaultConfig.ts
+++ b/app/component/ci/defaultConfig.ts
@@ -22,6 +22,7 @@ export const jenkinsDefaultConfig: JenkinsConfig = {
   user: '',
   token: '',
   repoToJobMap: [ ],
+  timeout: 30000,
 };
 
 const defaultConfig: Config = {

--- a/app/plugin/ci-manager/AppCIManager.ts
+++ b/app/plugin/ci-manager/AppCIManager.ts
@@ -41,7 +41,7 @@ export class AppCIManager extends AppPluginBase<null> {
       const url = config.endpoint + join('job', jobName, 'view/change-requests', 'job', 'PR-' + pullNum);
       this.logger.info(url);
 
-      const jenkinsCli = new Jenkins(config.user, config.token, config.endpoint);
+      const jenkinsCli = new Jenkins(config.user, config.token, config.endpoint, { timeout: config.timeout });
       await jenkinsCli.build(url).then(res => {
         this.logger.info(res.status);
       }).catch(e => {

--- a/app/third_party/jenkins/index.js
+++ b/app/third_party/jenkins/index.js
@@ -71,7 +71,7 @@ class Jenkins {
 
   async _getCrumb() {
     const url = `${this.baseUrl}/crumbIssuer/api/json`;
-    const result = await get(url);
+    const result = await get(url, this.headers);
     this.crumb = result;
     return result;
   }

--- a/test/plugin/ci-manager/AppCIManager.test.ts
+++ b/test/plugin/ci-manager/AppCIManager.test.ts
@@ -44,6 +44,7 @@ describe('AppCIManager', () => {
         user: 'a',
         token: 'a',
         repoToJobMap: null as any,
+        timeout: 10,
       });
     });
   });


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

<!--
Thank you for your interest in and contributing to Hypertrons! Follow this checklist to help us incorporate your contribution quickly and easily:

 - Each commit in the pull request has a meaningful commit message.
 - Make sure that you have signed our [Contributor License Agreement (CLA)](https://cla-assistant.io/hypertrons/hypertrons).
 - Fill out the template below to describe the changes contributed by the pull request.
 - Contributors guide: https://github.com/hypertrons/hypertrons/blob/master/CONTRIBUTING.md

 **(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

- Add timeout option to Jenkins plugin, default to 30s
- Modify `third-party` Jenkins client, add headers to `get` request to pass in `timeout` option

<!-- Please include the GitHub issue this fixes or resolves, if applicable, please also explain any extra purpose of this PR  -->

-   Closes #303 

## Brief change log

<!-- Please list out what major changes were made in this PR to address the issue: -->

-   Add timeout option to Jenkins

## Checklist

-   **Are tests written for added code?**
    <!-- If not, why not? -->
    -   [ ] Yes
    -   [x] No because: Fix current test case

-   **Did you introduce any new dependencies?**
    <!-- If so, which ones? -->
    -   [x] No
    -   [ ] Yes
        -   Dependency:
        -   Reason:
