### PR TITLE
refactor: version-based config service

### DIFF
--- a/app/basic/HostingPlatform/HostingConfigBase.ts
+++ b/app/basic/HostingPlatform/HostingConfigBase.ts
@@ -102,11 +102,6 @@ class HostingConfigCompConfigPrivate {
   description: 'Config description of current config',
 })
 class HostingConfigCompConfig {
-  @configProp({
-    description: 'Auto update configuration interval',
-    defaultValue: '0 */1 * * * *',
-  })
-  updateInterval: string;
 
   @configProp({
     description: 'The remote config path stored on hosting platform',

--- a/app/basic/HostingPlatform/HostingManagerBase.ts
+++ b/app/basic/HostingPlatform/HostingManagerBase.ts
@@ -73,7 +73,7 @@ export abstract class HostingManagerBase<THostingPlatform extends HostingBase<TC
     return undefined;
   }
 
-  public getHostingPlatformById(id: number): HostingBase<TConfig , TClient, TRawClient> | undefined {
+  public getHostingPlatformById(id: number): HostingBase<TConfig, TClient, TRawClient> | undefined {
     return this.hpMap.get(id);
   }
 

--- a/app/basic/HostingPlatform/event.ts
+++ b/app/basic/HostingPlatform/event.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { RepoEventBase } from '../../plugin/event-manager/events';
-import { RawDataStatus, RawData } from './HostingClientService/ConfigService';
+import { RawData } from './HostingClientService/ConfigService';
 import { Repo } from '../DataTypes';
 export type HostingPlatformTypes = 'github' | 'gitlab' | 'gitee';
 
@@ -58,12 +58,15 @@ export class HostingClientSyncDataEvent extends RepoEventBase {
 }
 
 export class HostingClientSyncConfigEvent extends RepoEventBase {
-  status: RawDataStatus;
+}
+
+export class HostingClientOnConfigFileChangedEvent extends RepoEventBase {
+  option: 'remove' | 'update';
 }
 
 export class HostingClientConfigInitedEvent extends RepoEventBase {
   rawData: RawData;
-  status: RawDataStatus | undefined;
+  version: number;
 }
 
 export class HostingClientRepoDataInitedEvent extends RepoEventBase {

--- a/app/basic/Utils.ts
+++ b/app/basic/Utils.ts
@@ -167,3 +167,8 @@ export function parsePrivateConfigFileName(configFileName: string): string {
 
   return join(paths[paths.length - 2], paths[paths.length - 1]);
 }
+
+export function getNanoTimeStamp(): number {
+  const [ sec, nano ] = process.hrtime();
+  return sec * 1e9 + nano;
+}

--- a/app/plugin/github/GitHubClient.ts
+++ b/app/plugin/github/GitHubClient.ts
@@ -127,6 +127,7 @@ export class GitHubClient extends HostingClientBase<GitHubConfig, Octokit> {
       const content = (res.data as any).content;
       return Buffer.from(content, 'base64').toString('ascii');
     } catch (e) {
+      this.logger.error(e);
       return undefined;
     }
   }

--- a/test/plugin/basic/HostingPlatform/HostingClientBase.test.ts
+++ b/test/plugin/basic/HostingPlatform/HostingClientBase.test.ts
@@ -121,14 +121,14 @@ describe('HostingClientBase', () => {
 
   describe('getLuaScript()', () => {
     it('right case', async () => {
-      (client.configService as any).config = { foo: { luaScript: 'lua' } };
+      (client.configService as any).luaScript = { weekly_report: 'weekly_report lua code' };
       const res = client.getLuaScript();
-      const compare = `local foo = function ()
-  local compName = 'foo'
-  local compConfig = config.foo
-lua
+      const compare = `local weekly_report = function ()
+  local compName = 'weekly_report'
+  local compConfig = config.weekly_report
+weekly_report lua code
 end
-foo()
+weekly_report()
 `;
       assert(res === compare);
     });

--- a/test/plugin/gitee/data/global-config.json
+++ b/test/plugin/gitee/data/global-config.json
@@ -23,7 +23,6 @@
               "secret": ""
             },
             "config": {
-              "updateInterval": "0 */1 * * * *",
               "remote": {
                 "filePath": ".github/hypertrons.json"
               },

--- a/test/plugin/github/GitHubTestUtil.ts
+++ b/test/plugin/github/GitHubTestUtil.ts
@@ -174,7 +174,6 @@ export async function initWebhooks(app: Application): Promise<any[]> {
         tokens: [ 'YOUR TOKEN' ],
       },
       config: {
-        updateInterval: '0 */1 * * * *',
         remote: {
           filePath: '.github/hypertrons.json',
           luaScriptPath: './github/lua/',
@@ -206,7 +205,6 @@ export async function initWebhooks(app: Application): Promise<any[]> {
     id: 0,
     ...githubConfig,
   });
-
   // wait until client inited
   let githubClient;
   let retryTime = 0;


### PR DESCRIPTION
Signed-off-by: WuShaoling <wsl6@outlook.com>

<!--
Thank you for your interest in and contributing to Hypertrons! Follow this checklist to help us incorporate your contribution quickly and easily:

 - Each commit in the pull request has a meaningful commit message.
 - Make sure that you have signed our [Contributor License Agreement (CLA)](https://cla-assistant.io/hypertrons/hypertrons).
 - Fill out the template below to describe the changes contributed by the pull request.
 - Contributors guide: https://github.com/hypertrons/hypertrons/blob/master/CONTRIBUTING.md

 **(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

<!-- Please include the GitHub issue this fixes or resolves, if applicable, please also explain any extra purpose of this PR  -->

-   Closes #306 

## Brief change log

<!-- Please list out what major changes were made in this PR to address the issue: -->

- The configuration update strategy of the previous version uses a timing mechanism, which is cumbersome to implement and difficult to troubleshoot when a problem occurs. At present, this version uses the mechanism of updating immediately after receiving the event, and each update has a version number (based on timestamp). By comparing the version number, the old configuration is prevented from overwriting the new configuration.

## Known issues

- When the remote configuration is updated, we will call the `getFileContent()` to fetch the remote configuration. If the `getFileContent()` fails, it will return undefined, and the `loadConfigFromRemote()` function will return `{}`. Another way is to return `undefined` and terminate the remote update operation. 

- `loadLuaScriptFromRemote()` has the same issue, we need to discuss to decide which mechanism to use.

## Checklist

-   **Are tests written for added code?**
    <!-- If not, why not? -->
    -   [x] Yes
    -   [ ] No because:

-   **Did you introduce any new dependencies?**
    <!-- If so, which ones? -->
    -   [x] No
    -   [ ] Yes
        -   Dependency:
        -   Reason:
