### PR TITLE
refactor: add update file sha to GitHub

### DIFF
--- a/app/plugin/github/GitHubClient.ts
+++ b/app/plugin/github/GitHubClient.ts
@@ -317,6 +317,13 @@ export class GitHubClient extends HostingClientBase<GitHubConfig, Octokit> {
   public async createOrUpdateFile(filePath: string, content: string, commitMessgae: string, branchName: string, cb?: () => void): Promise<void> {
     this.logger.info('createOrUpdateFile:', filePath);
     const content64 = Buffer.from(content).toString('base64');
+
+    // need to get file first, if exist, need to pass sha in
+    const originFile = await this.getFileContent(filePath);
+    let sha: string | undefined;
+    if (originFile) {
+      sha = originFile.sha;
+    }
     await this.rawClient.repos.createOrUpdateFile({
       repo: this.repo,
       owner: this.owner,
@@ -324,6 +331,7 @@ export class GitHubClient extends HostingClientBase<GitHubConfig, Octokit> {
       message: commitMessgae,
       path: filePath,
       branch: branchName,
+      sha,
     });
 
     if (cb) {


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

<!--
Thank you for your interest in and contributing to Hypertrons! Follow this checklist to help us incorporate your contribution quickly and easily:

 - Each commit in the pull request has a meaningful commit message.
 - Make sure that you have signed our [Contributor License Agreement (CLA)](https://cla-assistant.io/hypertrons/hypertrons).
 - Fill out the template below to describe the changes contributed by the pull request.
 - Contributors guide: https://github.com/hypertrons/hypertrons/blob/master/CONTRIBUTING.md

 **(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

<!-- Please include the GitHub issue this fixes or resolves, if applicable, please also explain any extra purpose of this PR  -->

-   Closes #353 , on GitHub, we need to get a file SHA to update an exist file, so we need to get the file first and get its SHA.

## Brief change log

<!-- Please list out what major changes were made in this PR to address the issue: -->

-   Fix update file interface.

## Checklist

-   **Are tests written for added code?**
    <!-- If not, why not? -->
    -   [ ] Yes
    -   [ ] No because:

-   **Did you introduce any new dependencies?**
    <!-- If so, which ones? -->
    -   [ ] No
    -   [ ] Yes
        -   Dependency:
        -   Reason:
