### PR TITLE
refactor: add 2 more tokens for data-cat instance

### DIFF
--- a/app/plugin/github/GitHubClient.ts
+++ b/app/plugin/github/GitHubClient.ts
@@ -47,8 +47,10 @@ export class GitHubClient extends HostingClientBase<GitHubConfig, Octokit> {
   protected async updateData(): Promise<void> {
     this.logger.info(`Start to update data for ${this.fullName}`);
 
-    // generate 2 tokens to get data in case insufficient rate limit
+    // generate 4 tokens to get data in case insufficient rate limit
     const tokens = [
+      await this.githubApp.getAccessToken(this.installationId, this.id),
+      await this.githubApp.getAccessToken(this.installationId, this.id),
       await this.githubApp.getAccessToken(this.installationId, this.id),
       await this.githubApp.getAccessToken(this.installationId, this.id),
     ];

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "tsc && egg-scripts start --daemon --title=egg-server-hypertrons",
     "stop": "egg-scripts stop --title=egg-server-hypertrons",
-    "dev": "egg-bin dev",
+    "dev": "egg-bin dev --max-old-space-size=8192 --port=80",
     "debug": "egg-bin debug",
     "test-local": "egg-bin test",
     "test": "npm run lint -- --fix && npm run cov && npm run tsc && npm run license-check",


### PR DESCRIPTION
We need more tokens to make sure the data-cat instance can init data for repos.

<!--
Thank you for your interest in and contributing to Hypertrons! Follow this checklist to help us incorporate your contribution quickly and easily:

 - Each commit in the pull request has a meaningful commit message.
 - Make sure that you have signed our [Contributor License Agreement (CLA)](https://cla-assistant.io/hypertrons/hypertrons).
 - Fill out the template below to describe the changes contributed by the pull request.
 - Contributors guide: https://github.com/hypertrons/hypertrons/blob/master/CONTRIBUTING.md

 **(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

<!-- Please include the GitHub issue this fixes or resolves, if applicable, please also explain any extra purpose of this PR  -->

-  Related to #472 

## Brief change log

<!-- Please list out what major changes were made in this PR to address the issue: -->

-  Add 2 more tokens to data-cat

## Checklist

-   **Are tests written for added code?**
    <!-- If not, why not? -->
    -   [ ] Yes
    -   [x] No because: No need

-   **Did you introduce any new dependencies?**
    <!-- If so, which ones? -->
    -   [x] No
    -   [ ] Yes
        -   Dependency:
        -   Reason:
